### PR TITLE
Fix metrics exporter usage

### DIFF
--- a/pkg/observability/observability.go
+++ b/pkg/observability/observability.go
@@ -194,7 +194,7 @@ func New(cfg Config) (*Observability, error) {
 	}
 
 	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithBatcher(jaegerExporter),
+		sdktrace.WithBatcher(otlpExporter),
 		sdktrace.WithResource(res),
 		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 	)


### PR DESCRIPTION
## Summary
- fix `Observability` tracer exporter variable so cache package builds

## Testing
- `go test ./...` *(fails: syntax errors & environment-specific failures)*

------
https://chatgpt.com/codex/tasks/task_e_685421888fec83338646720cf01dd308