### PR TITLE
Update kustomize paths

### DIFF
--- a/.github/workflows/deploy-direct.yml
+++ b/.github/workflows/deploy-direct.yml
@@ -92,13 +92,13 @@ jobs:
 
       - name: Update image tags in manifests
         run: |
-          cd deployments/kubernetes/staging
+          cd kubernetes/apps/zamaz/overlays/staging
           kustomize edit set image auth-service=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/auth-service:${{ needs.determine-environment.outputs.image_tag }}
           kustomize edit set image frontend=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/frontend:${{ needs.determine-environment.outputs.image_tag }}
 
       - name: Validate manifests
         run: |
-          kustomize build deployments/kubernetes/staging | kubectl apply --dry-run=client -f -
+          kustomize build kubernetes/apps/zamaz/overlays/staging | kubectl apply --dry-run=client -f -
           echo "✅ Manifests validation passed"
 
       - name: Deploy to staging
@@ -195,13 +195,13 @@ jobs:
 
       - name: Update image tags in manifests
         run: |
-          cd deployments/kubernetes/production
+          cd kubernetes/apps/zamaz/overlays/production
           kustomize edit set image auth-service=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/auth-service:${{ needs.determine-environment.outputs.image_tag }}
           kustomize edit set image frontend=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/frontend:${{ needs.determine-environment.outputs.image_tag }}
 
       - name: Validate manifests
         run: |
-          kustomize build deployments/kubernetes/production | kubectl apply --dry-run=client -f -
+          kustomize build kubernetes/apps/zamaz/overlays/production | kubectl apply --dry-run=client -f -
           echo "✅ Manifests validation passed"
 
       - name: Deploy to production

--- a/DEPLOYMENT_MANUAL.md
+++ b/DEPLOYMENT_MANUAL.md
@@ -130,7 +130,7 @@ kubectl create namespace zamaz-staging
 kubectl create namespace zamaz-monitoring
 
 # Apply RBAC
-kubectl apply -f deployments/kubernetes/rbac/
+kubectl apply -f kubernetes/apps/zamaz/base/serviceaccount.yaml
 ```
 
 ### 3. Secrets Management
@@ -197,7 +197,7 @@ helm install redis bitnami/redis \
 ### 5. Application Deployment
 ```bash
 # Deploy with Kustomize
-kubectl apply -k deployments/kubernetes/overlays/production
+kubectl apply -k kubernetes/apps/zamaz/overlays/production
 
 # Verify deployment
 kubectl get pods -n zamaz-prod

--- a/KUBERNETES_MIGRATION_GUIDE.md
+++ b/KUBERNETES_MIGRATION_GUIDE.md
@@ -247,7 +247,7 @@ kubectl get pods --all-namespaces | grep zamaz
 helm install zamaz charts/zamaz/ -n zamaz
 
 # Restore original Kustomize
-kubectl apply -k deployments/kubernetes/overlays/$ENVIRONMENT/
+kubectl apply -k kubernetes/apps/zamaz/overlays/$ENVIRONMENT/
 ```
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ docker run -d -p 8080:8080 mvp-auth:latest
 
 ### Kubernetes (Production)
 ```bash
-kubectl apply -k deployments/kubernetes/overlays/production/
+kubectl apply -k kubernetes/apps/zamaz/overlays/production/
 ```
 
 ### Local Binary

--- a/deployments/kubernetes/README.md
+++ b/deployments/kubernetes/README.md
@@ -43,7 +43,7 @@ kubernetes/
 ./scripts/deploy-k8s.sh staging
 
 # Or manually with kubectl
-kubectl apply -k deployments/kubernetes/overlays/staging
+kubectl apply -k kubernetes/apps/zamaz/overlays/staging
 
 # Dry run
 DRY_RUN=true ./scripts/deploy-k8s.sh staging
@@ -53,7 +53,7 @@ DRY_RUN=true ./scripts/deploy-k8s.sh staging
 
 ```bash
 # First, ensure secrets.env is populated with production values
-cd deployments/kubernetes/overlays/production
+cd kubernetes/apps/zamaz/overlays/production
 cp secrets.env.example secrets.env
 # Edit secrets.env with actual production values
 
@@ -97,7 +97,7 @@ The base configuration includes:
 
 1. Create a new overlay directory:
 ```bash
-mkdir -p deployments/kubernetes/overlays/dev
+mkdir -p kubernetes/apps/zamaz/overlays/dev
 ```
 
 2. Create kustomization.yaml:

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -53,7 +53,7 @@ graph TB
 ### Namespace
 
 ```yaml
-# deployments/kubernetes/base/namespace.yaml
+# kubernetes/apps/zamaz/base/namespace.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -67,7 +67,7 @@ metadata:
 ### ConfigMap
 
 ```yaml
-# deployments/kubernetes/base/configmap.yaml
+# kubernetes/apps/zamaz/base/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -111,7 +111,7 @@ data:
 ### Secrets
 
 ```yaml
-# deployments/kubernetes/base/secrets.yaml
+# kubernetes/apps/zamaz/base/secrets.yaml
 apiVersion: v1
 kind: Secret
 metadata:
@@ -140,7 +140,7 @@ data:
 ### Deployment
 
 ```yaml
-# deployments/kubernetes/base/deployment.yaml
+# kubernetes/apps/zamaz/base/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -324,7 +324,7 @@ spec:
 ### Service
 
 ```yaml
-# deployments/kubernetes/base/service.yaml
+# kubernetes/apps/zamaz/base/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
@@ -386,7 +386,7 @@ spec:
 ### RBAC
 
 ```yaml
-# deployments/kubernetes/base/rbac.yaml
+# kubernetes/apps/zamaz/base/rbac.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -426,7 +426,7 @@ roleRef:
 ### PostgreSQL Deployment
 
 ```yaml
-# deployments/kubernetes/base/postgres.yaml
+# kubernetes/apps/zamaz/base/postgres.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -520,7 +520,7 @@ spec:
 ### Redis Deployment
 
 ```yaml
-# deployments/kubernetes/base/redis.yaml
+# kubernetes/apps/zamaz/base/redis.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -602,7 +602,7 @@ spec:
 ### Ingress
 
 ```yaml
-# deployments/kubernetes/base/ingress.yaml
+# kubernetes/apps/zamaz/base/ingress.yaml
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -640,7 +640,7 @@ spec:
 ### Base Kustomization
 
 ```yaml
-# deployments/kubernetes/base/kustomization.yaml
+# kubernetes/apps/zamaz/base/kustomization.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
@@ -673,7 +673,7 @@ images:
 ### Production Overlay
 
 ```yaml
-# deployments/kubernetes/overlays/production/kustomization.yaml
+# kubernetes/apps/zamaz/overlays/production/kustomization.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
@@ -712,7 +712,7 @@ secretGenerator:
 ### Production Patches
 
 ```yaml
-# deployments/kubernetes/overlays/production/deployment-patch.yaml
+# kubernetes/apps/zamaz/overlays/production/deployment-patch.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -742,10 +742,10 @@ spec:
 
 ```bash
 # Create namespace
-kubectl apply -f deployments/kubernetes/base/namespace.yaml
+kubectl apply -f kubernetes/apps/zamaz/base/namespace.yaml
 
 # Deploy base resources
-kubectl apply -k deployments/kubernetes/base/
+kubectl apply -k kubernetes/apps/zamaz/base/
 
 # Check deployment status
 kubectl get pods -n mvp-auth
@@ -757,7 +757,7 @@ kubectl get ingress -n mvp-auth
 
 ```bash
 # Deploy production overlay
-kubectl apply -k deployments/kubernetes/overlays/production/
+kubectl apply -k kubernetes/apps/zamaz/overlays/production/
 
 # Check rollout status
 kubectl rollout status deployment/prod-mvp-auth -n mvp-auth-prod
@@ -813,7 +813,7 @@ spec:
 ### HorizontalPodAutoscaler
 
 ```yaml
-# deployments/kubernetes/overlays/production/hpa.yaml
+# kubernetes/apps/zamaz/overlays/production/hpa.yaml
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -857,7 +857,7 @@ spec:
 ### PodDisruptionBudget
 
 ```yaml
-# deployments/kubernetes/overlays/production/pdb.yaml
+# kubernetes/apps/zamaz/overlays/production/pdb.yaml
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -875,7 +875,7 @@ spec:
 ### Network Policies
 
 ```yaml
-# deployments/kubernetes/base/network-policy.yaml
+# kubernetes/apps/zamaz/base/network-policy.yaml
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/scripts/deploy-k8s.sh
+++ b/scripts/deploy-k8s.sh
@@ -19,7 +19,7 @@ KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
 # Base directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-K8S_DIR="${PROJECT_ROOT}/deployments/kubernetes"
+K8S_DIR="${PROJECT_ROOT}/kubernetes/apps/zamaz"
 
 # Log functions
 log_info() {


### PR DESCRIPTION
## Summary
- point deploy script to `kubernetes/apps/zamaz`
- deploy workflow uses new overlays
- refresh documentation references

## Testing
- `make test` *(fails: declared and not used: otlpExporter)*

------
https://chatgpt.com/codex/tasks/task_e_685423961ce48333bea657f47ab6a978