### PR TITLE
Add comprehensive development docs

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -272,7 +272,7 @@ type CacheLayer struct {
 - [ ] Generate client SDKs (Go, Python, JavaScript)
 - [ ] Create development environment setup scripts
 - [ ] Add code generation tools
-- [ ] Create comprehensive developer documentation
+ - [x] Create comprehensive developer documentation
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -74,9 +74,11 @@ Password: password
 ## 📖 Documentation
 
 ### Development
+- [Development Overview](docs/development/README.md)
 - [Development Setup](docs/development/setup.md)
 - [Build System](examples/build-examples.md)
 - [Testing Guide](docs/development/testing.md)
+- [Code Style Guide](docs/development/code-style.md)
 - [Contributing Guidelines](docs/development/contributing.md)
 
 ### API Documentation

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -1,0 +1,12 @@
+# Development Documentation
+
+Welcome to the Zero Trust Auth development docs. This section collects all resources needed to contribute effectively.
+
+## Contents
+
+- [Setup Guide](setup.md) — install prerequisites and run the project locally.
+- [Testing Guide](testing.md) — learn about the testing stack and how to run tests.
+- [Code Style Guide](code-style.md) — standards for Go and TypeScript code.
+- [Contributing](contributing.md) — workflow for contributing and submitting PRs.
+
+Refer back to this index whenever you need details about the development process.

--- a/docs/development/code-style.md
+++ b/docs/development/code-style.md
@@ -1,0 +1,35 @@
+# Code Style Guide
+
+This document outlines the coding standards used throughout the project for both Go and TypeScript code.
+
+## Go Guidelines
+
+- **Formatting**: All Go code must be formatted using `goimports`. Run `make fmt` before committing.
+- **Linting**: We use `golangci-lint` with the configuration in `.golangci.yml`. Run `make lint` to check for issues.
+- **Error Handling**: Prefer wrapped errors using `fmt.Errorf("context: %w", err)`.
+- **Testing**: Table-driven tests are encouraged. Aim for 80% coverage or higher.
+- **Packages**: Keep packages focused. Avoid cyclic dependencies and use internal packages when code should not be consumed externally.
+
+## TypeScript Guidelines
+
+- **Formatting**: The repository uses Prettier. Run `npm run format` in the `frontend` directory.
+- **Linting**: ESLint rules are enforced via `npm run lint`.
+- **Components**: Use functional React components and hooks. Keep files under 300 lines when possible.
+- **Types**: Prefer explicit types and interfaces. Avoid `any` except in tests or temporary code.
+
+## Commit Messages
+
+We follow [Conventional Commits](https://www.conventionalcommits.org/). Example:
+
+```
+feat(auth): add JWT middleware
+```
+
+Type scopes should match package or feature areas. Use the imperative mood and keep the summary under 72 characters.
+
+## Pull Requests
+
+- Keep PRs focused and small when possible.
+- Reference relevant issues in the description.
+- Ensure `make quality-check` and all tests pass before requesting review.
+

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -1,5 +1,39 @@
 # Contributing Guidelines
 
-This document is a placeholder for Contributing Guidelines. Information regarding how to contribute to this project will be added here.
+Thank you for taking the time to contribute! This project welcomes pull requests from the community. The following guidelines help keep the process smooth.
 
-_This file was auto-generated as part of a documentation update initiative._
+## Getting Started
+
+1. Fork the repository and clone your fork.
+2. Create a feature branch using a descriptive name: `git checkout -b feat/my-change`.
+3. Run `make dev-setup` to install dependencies and hooks.
+
+## Development Workflow
+
+- Follow the [Code Style Guide](code-style.md) for Go and TypeScript conventions.
+- Write or update tests for any code you change. Run `make test` to ensure all tests pass.
+- Use `make fmt` and `make lint` before committing.
+- Keep commits focused and use [Conventional Commits](https://www.conventionalcommits.org/).
+
+## Pull Requests
+
+1. Ensure your branch is up to date with `main`.
+2. Open a draft PR early if you'd like feedback.
+3. Fill out the PR template, describing the change and linking related issues.
+4. Verify CI checks pass. Run `make quality-check` locally to catch issues early.
+5. Request review from maintainers once ready.
+
+## Code Reviews
+
+- Reviews focus on correctness, readability, and alignment with project goals.
+- Address all comments or questions before merging.
+- Squash or rebase if necessary to keep history clean.
+
+## Reporting Issues
+
+If you encounter a bug or have a feature request, please open an issue with detailed steps to reproduce or a clear description of the desired behavior.
+
+## Community
+
+Join the discussion in GitHub issues to ask questions or share ideas. We appreciate all contributions, whether code, documentation, or feedback.
+


### PR DESCRIPTION
## Summary
- add developer documentation index
- provide code style guidelines
- update contributing guide with workflow details
- link new docs from README
- mark documentation task complete in implementation plan

## Testing
- `make test` *(fails: build errors in observability package)*

------
https://chatgpt.com/codex/tasks/task_e_68542181f9188333a5ac4465337060aa