### PR TITLE
Enable Swagger documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Password: password
 
 ### API Documentation
 - [Swagger UI](http://localhost:8080/swagger/index.html) (when running)
+- [Interactive Guide](docs/development/api-documentation.md)
 - [API Reference](docs/api/README.md)
 - [Authentication Flow](docs/api/authentication.md)
 - [Device Management](docs/api/devices.md)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -35,7 +35,8 @@ import (
 	"github.com/gofiber/fiber/v2/middleware/cors"
 	"github.com/gofiber/swagger"
 	"github.com/redis/go-redis/v9"
-	// _ "mvp.local/docs" // Import generated docs - disabled for build
+	_ "mvp.local/docs" // Import generated docs for Swagger UI
+	docspkg "mvp.local/pkg/docs"
 
 	"mvp.local/pkg/auth"
 	"mvp.local/pkg/config"
@@ -266,13 +267,13 @@ func (s *Server) setupRoutes() {
 
 	// Authentication routes (public)
 	authRoutes := api.Group("/auth")
-	authRoutes.Post("/login", 
+	authRoutes.Post("/login",
 		s.validationMiddleware.ValidateRequest(auth.LoginRequest{}),
 		authHandler.Login)
-	authRoutes.Post("/register", 
+	authRoutes.Post("/register",
 		s.validationMiddleware.ValidateRequest(handlers.RegisterRequest{}),
 		authHandler.Register)
-	authRoutes.Post("/refresh", 
+	authRoutes.Post("/refresh",
 		s.validationMiddleware.ValidateRequest(auth.RefreshRequest{}),
 		authHandler.RefreshToken)
 
@@ -319,7 +320,7 @@ func (s *Server) setupRoutes() {
 	adminRoutes.Delete("/users/:userId/roles/:roleId", adminHandler.RemoveRoleFromUser)
 
 	// Swagger documentation
-	s.app.Get("/swagger/*", swagger.HandlerDefault)
+	docspkg.SetupSwagger(s.app)
 
 	// Frontend routes (serve static files)
 	s.app.Static("/", "./frontend/dist")
@@ -381,7 +382,6 @@ func (s *Server) Start(ctx context.Context) error {
 		return nil
 	}
 }
-
 
 // joinStrings joins a slice of strings with a separator
 func joinStrings(slice []string, sep string) string {

--- a/docs/development/api-documentation.md
+++ b/docs/development/api-documentation.md
@@ -1,0 +1,32 @@
+# Interactive API Documentation
+
+This guide explains how to view and regenerate the interactive API documentation for the Zero Trust Authentication API.
+
+## Viewing the Documentation
+
+Run the server in development mode and open the Swagger UI in your browser:
+
+```
+make dev-up
+# in another terminal
+make dev-frontend
+```
+
+Once the services are running, navigate to:
+
+```
+http://localhost:8080/swagger/index.html
+```
+
+The Swagger UI provides an interactive interface to explore and test the API endpoints.
+
+## Regenerating the Swagger Spec
+
+API documentation is generated from source code comments using `swag`. To regenerate the OpenAPI specification:
+
+```
+make swag
+```
+
+This command runs `swag init` and updates the files in the `docs` package that are served by the Swagger UI.
+


### PR DESCRIPTION
## Summary
- enable serving Swagger docs via SetupSwagger
- link interactive API docs in README
- add new API documentation guide for developers

## Testing
- `go test ./...` *(fails: pkg/observability/observability.go:187:2: declared and not used: otlpExporter)*

------
https://chatgpt.com/codex/tasks/task_e_6854215788a48333b2a043f5f44d6ce1