### PR TITLE
Add developer CLI and SDK tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,11 @@ root-zamaz/
 └── tests/              # Integration and E2E tests
 ```
 
+### Developer CLI & SDK
+
+- [CLI Usage](docs/development/cli.md)
+- [SDK Generation](docs/development/sdk_generation.md)
+
 ## 🔒 Security Features
 
 ### Authentication & Authorization

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"mvp.local/pkg/client"
+	"mvp.local/pkg/handlers"
+)
+
+var (
+	apiURL   string
+	username string
+	password string
+	email    string
+	token    string
+)
+
+func main() {
+	rootCmd := &cobra.Command{
+		Use:   "mvpctl",
+		Short: "Developer CLI for Zero Trust Auth MVP",
+	}
+	rootCmd.PersistentFlags().StringVar(&apiURL, "api", "http://localhost:8080/api", "API base URL")
+
+	// login command
+	loginCmd := &cobra.Command{
+		Use:   "login",
+		Short: "Login and obtain a token",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := client.New(apiURL)
+			resp, err := c.Login(context.Background(), username, password)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("Token: %s\nRefresh: %s\n", resp.Token, resp.RefreshToken)
+			return nil
+		},
+	}
+	loginCmd.Flags().StringVarP(&username, "username", "u", "", "Username")
+	loginCmd.Flags().StringVarP(&password, "password", "p", "", "Password")
+	loginCmd.MarkFlagRequired("username")
+	loginCmd.MarkFlagRequired("password")
+
+	// register command
+	registerCmd := &cobra.Command{
+		Use:   "register",
+		Short: "Register a new user",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := client.New(apiURL)
+			req := handlers.RegisterRequest{Username: username, Email: email, Password: password}
+			resp, err := c.Register(context.Background(), req)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("User %s created\n", resp.ID)
+			return nil
+		},
+	}
+	registerCmd.Flags().StringVarP(&username, "username", "u", "", "Username")
+	registerCmd.Flags().StringVarP(&password, "password", "p", "", "Password")
+	registerCmd.Flags().StringVarP(&email, "email", "e", "", "Email")
+	registerCmd.MarkFlagRequired("username")
+	registerCmd.MarkFlagRequired("password")
+	registerCmd.MarkFlagRequired("email")
+
+	// whoami command
+	whoamiCmd := &cobra.Command{
+		Use:   "whoami",
+		Short: "Get current user info",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := client.New(apiURL)
+			resp, err := c.Me(context.Background(), token)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("User: %s (%s)\n", resp.Username, resp.Email)
+			return nil
+		},
+	}
+	whoamiCmd.Flags().StringVarP(&token, "token", "t", "", "Access token")
+	whoamiCmd.MarkFlagRequired("token")
+
+	rootCmd.AddCommand(loginCmd, registerCmd, whoamiCmd)
+
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/docs/development/cli.md
+++ b/docs/development/cli.md
@@ -1,0 +1,24 @@
+# Developer CLI
+
+The `mvpctl` command-line tool allows developers to interact with the Zero Trust Auth API.
+
+## Building
+
+```bash
+go build -o mvpctl ./cmd/cli
+```
+
+## Examples
+
+```bash
+# Login and get tokens
+./mvpctl login -u admin -p password
+
+# Register a new user
+./mvpctl register -u alice -e alice@example.com -p secret
+
+# Inspect the current user
+./mvpctl whoami -t <access-token>
+```
+
+The API base URL can be changed with the `--api` flag.

--- a/docs/development/sdk_generation.md
+++ b/docs/development/sdk_generation.md
@@ -1,0 +1,9 @@
+# SDK Generation
+
+Client SDKs can be generated from the OpenAPI specification using the provided script.
+
+```bash
+./scripts/generate-sdks.sh
+```
+
+The script uses the `openapitools/openapi-generator-cli` Docker image to create Go, Python and JavaScript SDKs under the `sdk/` directory.

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,0 +1,105 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"mvp.local/pkg/auth"
+	"mvp.local/pkg/handlers"
+)
+
+// APIClient provides simplified access to the Zero Trust Auth API
+// It is intended for developer tooling and SDK generation.
+type APIClient struct {
+	BaseURL    string
+	HTTPClient *http.Client
+}
+
+// New creates a new API client with the given base URL.
+func New(baseURL string) *APIClient {
+	return &APIClient{
+		BaseURL:    baseURL,
+		HTTPClient: &http.Client{Timeout: 15 * time.Second},
+	}
+}
+
+// Login authenticates a user and returns JWT tokens.
+func (c *APIClient) Login(ctx context.Context, username, password string) (*auth.LoginResponse, error) {
+	reqBody, _ := json.Marshal(auth.LoginRequest{Username: username, Password: password})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/auth/login", bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("login failed: %s", resp.Status)
+	}
+
+	var lr auth.LoginResponse
+	if err := json.NewDecoder(resp.Body).Decode(&lr); err != nil {
+		return nil, err
+	}
+	return &lr, nil
+}
+
+// Register creates a new user account.
+func (c *APIClient) Register(ctx context.Context, r handlers.RegisterRequest) (*handlers.UserResponse, error) {
+	reqBody, _ := json.Marshal(r)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/auth/register", bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("registration failed: %s", resp.Status)
+	}
+
+	var ur handlers.UserResponse
+	if err := json.NewDecoder(resp.Body).Decode(&ur); err != nil {
+		return nil, err
+	}
+	return &ur, nil
+}
+
+// Me returns the currently authenticated user's information.
+func (c *APIClient) Me(ctx context.Context, token string) (*handlers.UserResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.BaseURL+"/auth/me", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("request failed: %s", resp.Status)
+	}
+
+	var ur handlers.UserResponse
+	if err := json.NewDecoder(resp.Body).Decode(&ur); err != nil {
+		return nil, err
+	}
+	return &ur, nil
+}

--- a/scripts/generate-sdks.sh
+++ b/scripts/generate-sdks.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+OPENAPI_FILE=${OPENAPI_FILE:-docs/swagger.yaml}
+OUTPUT_DIR=${OUTPUT_DIR:-sdk}
+
+LANGS=(go python javascript)
+
+for lang in "${LANGS[@]}"; do
+  echo "Generating $lang SDK..."
+  docker run --rm -v "$(pwd):/local" openapitools/openapi-generator-cli generate \
+    -i "/local/$OPENAPI_FILE" -g "$lang" -o "/local/$OUTPUT_DIR/$lang"
+done
+
+echo "SDKs generated in $OUTPUT_DIR/"


### PR DESCRIPTION
## Summary
- implement `mvpctl` CLI for login, register and whoami
- add `client` package for interacting with the API
- script for generating Go/Python/JS SDKs
- document CLI usage and SDK generation
- update README with Developer CLI section

## Testing
- `shellcheck scripts/generate-sdks.sh`
- `go test ./...` *(fails: VALIDATION_ERROR and build issues)*

------
https://chatgpt.com/codex/tasks/task_e_6854217c66ac83339c8e1350d74429d9