### PR TITLE
Enhance audit logging with compliance data

### DIFF
--- a/pkg/audit/service.go
+++ b/pkg/audit/service.go
@@ -4,12 +4,12 @@ package audit
 import (
 	"context"
 	"encoding/json"
-	"time"
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 	"mvp.local/pkg/models"
 	"mvp.local/pkg/observability"
+	"time"
 )
 
 // Service provides audit logging functionality
@@ -20,12 +20,14 @@ type Service struct {
 
 // LogEntry represents an audit log entry
 type LogEntry struct {
-	UserID    string
-	Action    string
-	Resource  string
-	Details   map[string]interface{}
-	Success   bool
-	Context   *fiber.Ctx
+	UserID        string
+	Action        string
+	Resource      string
+	Details       map[string]interface{}
+	Success       bool
+	Context       *fiber.Ctx
+	ComplianceTag string
+	Retention     time.Duration
 }
 
 // NewService creates a new audit service
@@ -36,30 +38,38 @@ func NewService(db *gorm.DB, obs *observability.Observability) *Service {
 // LogEvent logs an audit event
 func (s *Service) LogEvent(entry LogEntry) {
 	detailsJSON, _ := json.Marshal(entry.Details)
-	
+
 	var userIDPtr *uuid.UUID
 	if entry.UserID != "" {
 		if parsed, err := uuid.Parse(entry.UserID); err == nil {
 			userIDPtr = &parsed
 		}
 	}
-	
-	auditLog := models.AuditLog{
-		UserID:    userIDPtr,
-		Action:    entry.Action,
-		Resource:  entry.Resource,
-		Details:   string(detailsJSON),
-		IPAddress: entry.Context.IP(),
-		UserAgent: entry.Context.Get("User-Agent"),
-		RequestID: entry.Context.Get("X-Correlation-ID"),
-		Success:   entry.Success,
+
+	var retainUntil *time.Time
+	if entry.Retention > 0 {
+		t := time.Now().Add(entry.Retention)
+		retainUntil = &t
 	}
-	
+
+	auditLog := models.AuditLog{
+		UserID:        userIDPtr,
+		Action:        entry.Action,
+		Resource:      entry.Resource,
+		Details:       string(detailsJSON),
+		IPAddress:     entry.Context.IP(),
+		UserAgent:     entry.Context.Get("User-Agent"),
+		RequestID:     entry.Context.Get("X-Correlation-ID"),
+		Success:       entry.Success,
+		ComplianceTag: entry.ComplianceTag,
+		RetainUntil:   retainUntil,
+	}
+
 	// Save audit log (non-blocking) with timeout protection
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		
+
 		if err := s.db.WithContext(ctx).Create(&auditLog).Error; err != nil {
 			s.obs.Logger.Error().Err(err).Msg("Failed to save audit log")
 		}
@@ -84,11 +94,11 @@ func (s *Service) LogDeviceEvent(ctx *fiber.Ctx, userID, deviceID, event string,
 		details = make(map[string]interface{})
 	}
 	details["device_id"] = deviceID
-	
+
 	s.LogEvent(LogEntry{
 		UserID:   userID,
 		Action:   event,
-		Resource: "device", 
+		Resource: "device",
 		Details:  details,
 		Success:  success,
 		Context:  ctx,

--- a/pkg/audit/service_test.go
+++ b/pkg/audit/service_test.go
@@ -1,0 +1,44 @@
+package audit
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+
+	"mvp.local/pkg/models"
+	"mvp.local/pkg/testutil"
+)
+
+func TestLogEventCompliance(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	obs := testutil.NewMockObservability()
+	svc := NewService(db, obs)
+
+	app := fiber.New()
+	ctx := app.AcquireCtx(new(fasthttp.RequestCtx))
+	defer app.ReleaseCtx(ctx)
+
+	svc.LogEvent(LogEntry{
+		Action:        "test",
+		Resource:      "system",
+		Details:       map[string]interface{}{"foo": "bar"},
+		Success:       true,
+		Context:       ctx,
+		ComplianceTag: "GDPR",
+		Retention:     24 * time.Hour,
+	})
+
+	time.Sleep(100 * time.Millisecond)
+
+	var count int64
+	require.NoError(t, db.Model(&models.AuditLog{}).Count(&count).Error)
+	require.Equal(t, int64(1), count)
+
+	var logEntry models.AuditLog
+	require.NoError(t, db.First(&logEntry).Error)
+	require.Equal(t, "GDPR", logEntry.ComplianceTag)
+	require.WithinDuration(t, time.Now().Add(24*time.Hour), *logEntry.RetainUntil, time.Second)
+}

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -556,5 +556,18 @@ DROP INDEX CONCURRENTLY IF EXISTS idx_audit_logs_user_action_time;
 DROP INDEX CONCURRENTLY IF EXISTS idx_user_sessions_user_device_active;
 `,
 		},
+		{
+			ID:          "005_audit_compliance_fields",
+			Description: "Add compliance tag and retention fields to audit logs",
+			Version:     1640995600, // 2022-01-01 + 400 seconds
+			UpSQL: `
+ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS compliance_tag VARCHAR(50);
+ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS retain_until TIMESTAMP WITH TIME ZONE;
+`,
+			DownSQL: `
+ALTER TABLE audit_logs DROP COLUMN IF EXISTS compliance_tag;
+ALTER TABLE audit_logs DROP COLUMN IF EXISTS retain_until;
+`,
+		},
 	}
 }

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -75,9 +75,9 @@ type DeviceAttestation struct {
 
 	// Device identification
 	UserID     uuid.UUID `gorm:"not null;index;type:uuid" json:"user_id"`
-	User       User   `json:"user,omitempty"`
-	DeviceID   string `gorm:"uniqueIndex;not null;size:100" json:"device_id"`
-	DeviceName string `gorm:"size:100" json:"device_name"`
+	User       User      `json:"user,omitempty"`
+	DeviceID   string    `gorm:"uniqueIndex;not null;size:100" json:"device_id"`
+	DeviceName string    `gorm:"size:100" json:"device_name"`
 
 	// Attestation data
 	TrustLevel      int        `gorm:"default:0" json:"trust_level"`
@@ -134,11 +134,11 @@ type LoginAttempt struct {
 	// Attempt details
 	Username      string     `gorm:"not null;size:50;index" json:"username"`
 	UserID        *uuid.UUID `gorm:"type:uuid;index" json:"user_id"`
-	User          *User   `json:"user,omitempty"`
-	IPAddress     string  `gorm:"not null;size:45;index" json:"ip_address"`
-	UserAgent     string  `gorm:"size:500" json:"user_agent"`
-	Success       bool    `gorm:"default:false;index" json:"success"`
-	FailureReason string  `gorm:"size:200" json:"failure_reason"`
+	User          *User      `json:"user,omitempty"`
+	IPAddress     string     `gorm:"not null;size:45;index" json:"ip_address"`
+	UserAgent     string     `gorm:"size:500" json:"user_agent"`
+	Success       bool       `gorm:"default:false;index" json:"success"`
+	FailureReason string     `gorm:"size:200" json:"failure_reason"`
 
 	// Security tracking
 	IsSuspicious  bool   `gorm:"default:false;index" json:"is_suspicious"`
@@ -153,10 +153,10 @@ type AuditLog struct {
 
 	// Audit details
 	UserID   *uuid.UUID `gorm:"index;type:uuid" json:"user_id"`
-	User     *User   `json:"user,omitempty"`
-	Action   string  `gorm:"not null;size:100" json:"action"`
-	Resource string  `gorm:"size:100" json:"resource"`
-	Details  string  `gorm:"type:jsonb" json:"details"` // JSON data
+	User     *User      `json:"user,omitempty"`
+	Action   string     `gorm:"not null;size:100" json:"action"`
+	Resource string     `gorm:"size:100" json:"resource"`
+	Details  string     `gorm:"type:jsonb" json:"details"` // JSON data
 
 	// Request context
 	IPAddress string `gorm:"size:45" json:"ip_address"`
@@ -164,6 +164,10 @@ type AuditLog struct {
 	RequestID string `gorm:"size:100" json:"request_id"`
 	Success   bool   `gorm:"default:false" json:"success"`
 	ErrorMsg  string `gorm:"size:500" json:"error_msg"`
+
+	// Compliance context
+	ComplianceTag string     `gorm:"size:50" json:"compliance_tag"`
+	RetainUntil   *time.Time `json:"retain_until"`
 }
 
 // TableName methods for custom table names if needed

--- a/pkg/testutil/mocks.go
+++ b/pkg/testutil/mocks.go
@@ -249,21 +249,23 @@ func SetupTestDB(t *testing.T) *gorm.DB {
 			UNIQUE(user_id, device_id)
 		);
 		
-		CREATE TABLE audit_logs (
-			id TEXT PRIMARY KEY,
-			created_at DATETIME,
-			updated_at DATETIME,
-			deleted_at DATETIME,
-			user_id TEXT,
-			action TEXT NOT NULL,
-			resource TEXT NOT NULL,
-			details TEXT,
-			ip_address TEXT,
-			user_agent TEXT,
-			request_id TEXT,
-			success BOOLEAN DEFAULT 1,
-			error_message TEXT
-		);
+                CREATE TABLE audit_logs (
+                        id TEXT PRIMARY KEY,
+                        created_at DATETIME,
+                        updated_at DATETIME,
+                        deleted_at DATETIME,
+                        user_id TEXT,
+                        action TEXT NOT NULL,
+                        resource TEXT NOT NULL,
+                        details TEXT,
+                        ip_address TEXT,
+                        user_agent TEXT,
+                        request_id TEXT,
+                        success BOOLEAN DEFAULT 1,
+                        error_message TEXT,
+                        compliance_tag TEXT,
+                        retain_until DATETIME
+                );
 		
 		CREATE TABLE user_roles (
 			user_id TEXT NOT NULL,


### PR DESCRIPTION
## Summary
- extend `AuditLog` model with compliance fields
- update audit service to capture compliance info and retention policy
- add migration for new audit log columns
- update test DB schema for compliance columns
- add unit test covering compliance audit logging

## Testing
- `go test ./...` *(fails: pkg/observability build issues)*

------
https://chatgpt.com/codex/tasks/task_e_6854216f3fb883339062b6410d392d49