### PR TITLE
Implement request signing for API security

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -51,30 +51,30 @@ type TLSConfig struct {
 
 // DatabaseConfig contains database connection settings
 type DatabaseConfig struct {
-	Host            string        `yaml:"host" env:"DB_HOST" default:"localhost"`
-	Port            int           `yaml:"port" env:"DB_PORT" default:"5432"`
-	Database        string        `yaml:"database" env:"DB_NAME" default:"mvp_db"`
-	Username        string        `yaml:"username" env:"DB_USER" default:"mvp_user"`
-	Password        string        `yaml:"password" env:"DB_PASSWORD" default:"please_change_this_password_in_production"`
-	SSLMode         string        `yaml:"ssl_mode" env:"DB_SSL_MODE" default:"disable"`
-	
+	Host     string `yaml:"host" env:"DB_HOST" default:"localhost"`
+	Port     int    `yaml:"port" env:"DB_PORT" default:"5432"`
+	Database string `yaml:"database" env:"DB_NAME" default:"mvp_db"`
+	Username string `yaml:"username" env:"DB_USER" default:"mvp_user"`
+	Password string `yaml:"password" env:"DB_PASSWORD" default:"please_change_this_password_in_production"`
+	SSLMode  string `yaml:"ssl_mode" env:"DB_SSL_MODE" default:"disable"`
+
 	// Connection pool settings
-	MaxConnections    int           `yaml:"max_connections" env:"DB_MAX_CONNECTIONS" default:"25"`
-	MaxIdleConns      int           `yaml:"max_idle_conns" env:"DB_MAX_IDLE_CONNS" default:"5"`
-	MinIdleConns      int           `yaml:"min_idle_conns" env:"DB_MIN_IDLE_CONNS" default:"2"`
-	ConnMaxLifetime   time.Duration `yaml:"conn_max_lifetime" env:"DB_CONN_MAX_LIFETIME" default:"300s"`
-	ConnMaxIdleTime   time.Duration `yaml:"conn_max_idle_time" env:"DB_CONN_MAX_IDLE_TIME" default:"60s"`
-	
+	MaxConnections  int           `yaml:"max_connections" env:"DB_MAX_CONNECTIONS" default:"25"`
+	MaxIdleConns    int           `yaml:"max_idle_conns" env:"DB_MAX_IDLE_CONNS" default:"5"`
+	MinIdleConns    int           `yaml:"min_idle_conns" env:"DB_MIN_IDLE_CONNS" default:"2"`
+	ConnMaxLifetime time.Duration `yaml:"conn_max_lifetime" env:"DB_CONN_MAX_LIFETIME" default:"300s"`
+	ConnMaxIdleTime time.Duration `yaml:"conn_max_idle_time" env:"DB_CONN_MAX_IDLE_TIME" default:"60s"`
+
 	// Query timeouts
-	QueryTimeout      time.Duration `yaml:"query_timeout" env:"DB_QUERY_TIMEOUT" default:"30s"`
-	ConnectTimeout    time.Duration `yaml:"connect_timeout" env:"DB_CONNECT_TIMEOUT" default:"10s"`
-	
+	QueryTimeout   time.Duration `yaml:"query_timeout" env:"DB_QUERY_TIMEOUT" default:"30s"`
+	ConnectTimeout time.Duration `yaml:"connect_timeout" env:"DB_CONNECT_TIMEOUT" default:"10s"`
+
 	// Performance tuning
-	PrepareStmt       bool          `yaml:"prepare_stmt" env:"DB_PREPARE_STMT" default:"true"`
-	DisableForeignKey bool          `yaml:"disable_foreign_key" env:"DB_DISABLE_FOREIGN_KEY" default:"false"`
-	
+	PrepareStmt       bool `yaml:"prepare_stmt" env:"DB_PREPARE_STMT" default:"true"`
+	DisableForeignKey bool `yaml:"disable_foreign_key" env:"DB_DISABLE_FOREIGN_KEY" default:"false"`
+
 	// Monitoring
-	EnableMetrics     bool          `yaml:"enable_metrics" env:"DB_ENABLE_METRICS" default:"true"`
+	EnableMetrics      bool          `yaml:"enable_metrics" env:"DB_ENABLE_METRICS" default:"true"`
 	SlowQueryThreshold time.Duration `yaml:"slow_query_threshold" env:"DB_SLOW_QUERY_THRESHOLD" default:"1s"`
 }
 
@@ -120,16 +120,17 @@ type ObservabilityConfig struct {
 
 // SecurityConfig contains security-related settings
 type SecurityConfig struct {
-	SPIRE              SPIREConfig     `yaml:"spire"`
-	JWT                JWTConfig       `yaml:"jwt"`
-	CORS               CORSConfig      `yaml:"cors"`
-	RateLimit          RateLimitConfig `yaml:"rate_limit"`
-	Lockout            LockoutConfig   `yaml:"lockout"`
-	TrustedProxies     []string        `yaml:"trusted_proxies" env:"TRUSTED_PROXIES"`
-	AllowedOrigins     []string        `yaml:"allowed_origins" env:"ALLOWED_ORIGINS"`
-	SecureHeaders      bool            `yaml:"secure_headers" env:"SECURE_HEADERS" default:"true"`
-	ContentTypeNosniff bool            `yaml:"content_type_nosniff" env:"CONTENT_TYPE_NOSNIFF" default:"true"`
-	DisableAuth        bool            `yaml:"disable_auth" env:"DISABLE_AUTH" default:"false"`
+	SPIRE              SPIREConfig          `yaml:"spire"`
+	JWT                JWTConfig            `yaml:"jwt"`
+	CORS               CORSConfig           `yaml:"cors"`
+	RateLimit          RateLimitConfig      `yaml:"rate_limit"`
+	Lockout            LockoutConfig        `yaml:"lockout"`
+	RequestSigning     RequestSigningConfig `yaml:"request_signing"`
+	TrustedProxies     []string             `yaml:"trusted_proxies" env:"TRUSTED_PROXIES"`
+	AllowedOrigins     []string             `yaml:"allowed_origins" env:"ALLOWED_ORIGINS"`
+	SecureHeaders      bool                 `yaml:"secure_headers" env:"SECURE_HEADERS" default:"true"`
+	ContentTypeNosniff bool                 `yaml:"content_type_nosniff" env:"CONTENT_TYPE_NOSNIFF" default:"true"`
+	DisableAuth        bool                 `yaml:"disable_auth" env:"DISABLE_AUTH" default:"false"`
 }
 
 // SPIREConfig contains SPIRE workload identity settings
@@ -184,6 +185,17 @@ type LockoutConfig struct {
 	IPLockoutEnabled    bool          `yaml:"ip_lockout_enabled" env:"IP_LOCKOUT_ENABLED" default:"true"`
 	IPLockoutThreshold  int           `yaml:"ip_lockout_threshold" env:"IP_LOCKOUT_THRESHOLD" default:"10"`
 	IPLockoutDuration   time.Duration `yaml:"ip_lockout_duration" env:"IP_LOCKOUT_DURATION" default:"1h"`
+}
+
+// RequestSigningConfig contains settings for API request signing
+type RequestSigningConfig struct {
+	Enabled      bool          `yaml:"enabled" env:"REQUEST_SIGNING_ENABLED" default:"false"`
+	Algorithm    string        `yaml:"algorithm" env:"REQUEST_SIGNING_ALGORITHM" default:"HMAC-SHA256"`
+	KeyID        string        `yaml:"key_id" env:"REQUEST_SIGNING_KEY_ID"`
+	Secret       string        `yaml:"secret" env:"REQUEST_SIGNING_SECRET"`
+	Headers      []string      `yaml:"headers" env:"REQUEST_SIGNING_HEADERS"`
+	MaxClockSkew time.Duration `yaml:"max_clock_skew" env:"REQUEST_SIGNING_MAX_CLOCK_SKEW" default:"5s"`
+	ReplayWindow time.Duration `yaml:"replay_window" env:"REQUEST_SIGNING_REPLAY_WINDOW" default:"1m"`
 }
 
 // Load loads configuration from environment variables with defaults
@@ -357,6 +369,15 @@ func loadFromEnv(config *Config) error {
 	config.Security.Lockout.IPLockoutThreshold = getEnvIntWithDefault("IP_LOCKOUT_THRESHOLD", 10)
 	config.Security.Lockout.IPLockoutDuration = getEnvDurationWithDefault("IP_LOCKOUT_DURATION", 1*time.Hour)
 
+	// Set Request Signing config
+	config.Security.RequestSigning.Enabled = getEnvBoolWithDefault("REQUEST_SIGNING_ENABLED", false)
+	config.Security.RequestSigning.Algorithm = getEnvWithDefault("REQUEST_SIGNING_ALGORITHM", "HMAC-SHA256")
+	config.Security.RequestSigning.KeyID = getEnvWithDefault("REQUEST_SIGNING_KEY_ID", "")
+	config.Security.RequestSigning.Secret = getEnvWithDefault("REQUEST_SIGNING_SECRET", "")
+	config.Security.RequestSigning.Headers = getEnvSliceWithDefault("REQUEST_SIGNING_HEADERS", []string{})
+	config.Security.RequestSigning.MaxClockSkew = getEnvDurationWithDefault("REQUEST_SIGNING_MAX_CLOCK_SKEW", 5*time.Second)
+	config.Security.RequestSigning.ReplayWindow = getEnvDurationWithDefault("REQUEST_SIGNING_REPLAY_WINDOW", time.Minute)
+
 	return nil
 }
 
@@ -477,6 +498,13 @@ func validateConfig(config *Config) error {
 
 	if config.Security.Lockout.ResetWindow <= 0 {
 		return errors.Validation("lockout.reset_window must be positive")
+	}
+
+	// Validate request signing configuration
+	if config.Security.RequestSigning.Enabled {
+		if config.Security.RequestSigning.Secret == "" {
+			return errors.Validation("request_signing.secret is required when request signing is enabled")
+		}
 	}
 
 	// Validate HTTP timeouts

--- a/pkg/middleware/request_signing.go
+++ b/pkg/middleware/request_signing.go
@@ -1,0 +1,18 @@
+package middleware
+
+import (
+	"github.com/gofiber/fiber/v2"
+
+	"mvp.local/pkg/errors"
+	"mvp.local/pkg/security"
+)
+
+// RequestSigningMiddleware validates request signatures.
+func RequestSigningMiddleware(validator *security.SignatureValidator) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		if err := validator.Validate(c.Request()); err != nil {
+			return errors.Unauthorized("invalid request signature").WithDetails(err.Error())
+		}
+		return c.Next()
+	}
+}

--- a/pkg/security/request_signing.go
+++ b/pkg/security/request_signing.go
@@ -1,0 +1,149 @@
+package security
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"mvp.local/pkg/errors"
+)
+
+// Constants for signature headers
+const (
+	SignatureHeader          = "X-Signature"
+	SignatureTimestampHeader = "X-Signature-Timestamp"
+	SignatureKeyIDHeader     = "X-Signature-Key"
+)
+
+// RequestSigner signs HTTP requests using HMAC-SHA256.
+type RequestSigner struct {
+	Algorithm string
+	KeyID     string
+	Key       []byte
+	Headers   []string
+}
+
+// SignatureValidation defines validation parameters.
+type SignatureValidation struct {
+	MaxClockSkew time.Duration
+	ReplayWindow time.Duration
+}
+
+// SignatureValidator verifies signed requests.
+type SignatureValidator struct {
+	Keys         map[string][]byte
+	Headers      []string
+	MaxClockSkew time.Duration
+	ReplayWindow time.Duration
+
+	mu   sync.Mutex
+	seen map[string]time.Time
+}
+
+// NewRequestSigner creates a new RequestSigner.
+func NewRequestSigner(keyID string, key []byte, headers []string) *RequestSigner {
+	return &RequestSigner{
+		Algorithm: "HMAC-SHA256",
+		KeyID:     keyID,
+		Key:       key,
+		Headers:   headers,
+	}
+}
+
+// Sign adds signature headers to the request.
+func (s *RequestSigner) Sign(req *http.Request) error {
+	ts := time.Now().UTC().Format(time.RFC3339)
+	canonical := buildCanonicalString(req, ts, s.Headers)
+
+	mac := hmac.New(sha256.New, s.Key)
+	_, err := mac.Write([]byte(canonical))
+	if err != nil {
+		return errors.Internal("failed to sign request")
+	}
+	sig := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+
+	req.Header.Set(SignatureHeader, sig)
+	req.Header.Set(SignatureTimestampHeader, ts)
+	req.Header.Set(SignatureKeyIDHeader, s.KeyID)
+	return nil
+}
+
+// NewSignatureValidator creates a validator for signed requests.
+func NewSignatureValidator(keys map[string][]byte, headers []string, v SignatureValidation) *SignatureValidator {
+	return &SignatureValidator{
+		Keys:         keys,
+		Headers:      headers,
+		MaxClockSkew: v.MaxClockSkew,
+		ReplayWindow: v.ReplayWindow,
+		seen:         make(map[string]time.Time),
+	}
+}
+
+// Validate checks the signature on the request.
+func (v *SignatureValidator) Validate(req *http.Request) error {
+	tsStr := req.Header.Get(SignatureTimestampHeader)
+	if tsStr == "" {
+		return errors.Authentication("missing signature timestamp")
+	}
+	ts, err := time.Parse(time.RFC3339, tsStr)
+	if err != nil {
+		return errors.Authentication("invalid signature timestamp")
+	}
+	now := time.Now().UTC()
+	if ts.Before(now.Add(-v.MaxClockSkew)) || ts.After(now.Add(v.MaxClockSkew)) {
+		return errors.Authentication("signature timestamp out of range")
+	}
+
+	keyID := req.Header.Get(SignatureKeyIDHeader)
+	key, ok := v.Keys[keyID]
+	if !ok {
+		return errors.Authentication("unknown signature key")
+	}
+
+	sig := req.Header.Get(SignatureHeader)
+	if sig == "" {
+		return errors.Authentication("missing signature header")
+	}
+
+	canonical := buildCanonicalString(req, tsStr, v.Headers)
+	mac := hmac.New(sha256.New, key)
+	mac.Write([]byte(canonical))
+	expected := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+
+	if !hmac.Equal([]byte(sig), []byte(expected)) {
+		return errors.Authentication("invalid request signature")
+	}
+
+	// Replay protection
+	if v.ReplayWindow > 0 {
+		v.mu.Lock()
+		defer v.mu.Unlock()
+		if t, found := v.seen[sig]; found && now.Sub(t) < v.ReplayWindow {
+			return errors.Authentication("replay attack detected")
+		}
+		v.seen[sig] = now
+	}
+
+	return nil
+}
+
+func buildCanonicalString(req *http.Request, ts string, headers []string) string {
+	var b strings.Builder
+	b.WriteString(req.Method)
+	b.WriteString("\n")
+	b.WriteString(req.URL.RequestURI())
+	b.WriteString("\n")
+	b.WriteString(ts)
+	b.WriteString("\n")
+	for _, h := range headers {
+		b.WriteString(strings.ToLower(h))
+		b.WriteString(":")
+		b.WriteString(req.Header.Get(h))
+		b.WriteString("\n")
+	}
+	return b.String()
+}

--- a/pkg/security/request_signing_test.go
+++ b/pkg/security/request_signing_test.go
@@ -1,0 +1,23 @@
+package security
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequestSigningAndValidation(t *testing.T) {
+	signer := NewRequestSigner("test-key", []byte("secret"), []string{"Content-Type"})
+	v := NewSignatureValidator(map[string][]byte{"test-key": []byte("secret")}, []string{"Content-Type"}, SignatureValidation{MaxClockSkew: 5 * time.Second})
+
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	req.Header.Set("Content-Type", "application/json")
+
+	err := signer.Sign(req)
+	assert.NoError(t, err)
+
+	err = v.Validate(req)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
## Summary
- add request signing implementation with HMAC signatures
- add middleware for validating signed requests
- extend configuration with request signing options
- include unit test for signer/validator

## Testing
- `go test ./...` *(fails: package build errors)*


------
https://chatgpt.com/codex/tasks/task_e_68542167e9488333a74d18203663941f