### PR TITLE
feat: Add Makefile target for schema documentation using tbls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ DB_PORT ?= 5432
 DB_NAME ?= mvp_db
 DB_USER ?= mvp_user
 DB_PASSWORD ?= mvp_password
+DB_SSLMODE ?= disable
 NATS_URL ?= nats://localhost:4222
 REDIS_URL ?= redis://localhost:6379
 COMPOSE_FILE ?= docker-compose.yml
@@ -71,7 +72,7 @@ BOLD := \033[1m
 	db-analyze db-monitor db-health db-tune db-perf-test \
 	cache cache-clean cache-warmup \
 	db db-migrate db-reset db-backup db-restore \
-	docs docs-generate docs-serve docs-deploy \
+	docs docs-generate docs-serve docs-deploy install-tbls \
 	monitor monitor-setup monitor-status monitor-logs \
 	gitops-setup gitops-validate gitops-sync gitops-rollback \
 	gitops-test gitops-deploy gitops-monitor gitops-backup \
@@ -1731,9 +1732,27 @@ db-restore: ## Restore database from backup (set BACKUP_FILE)
 # =============================================================================
 # DOCUMENTATION
 # =============================================================================
-docs: docs-generate ## 📚 Generate and serve documentation
+docs: docs-generate docs-schema ## 📚 Generate and serve documentation
 
-docs-generate: ## Generate API documentation
+install-tbls: ## Install tbls CLI for schema documentation
+	@printf "$(BLUE)🔧 Checking for tbls CLI...$(RESET)\n"
+	@if command -v tbls >/dev/null 2>&1; then \
+		printf "$(GREEN)✅ tbls is already installed: $$(command -v tbls)$(RESET)\n"; \
+	elif [ -f "$$HOME/go/bin/tbls" ]; then \
+		printf "$(GREEN)✅ tbls is installed in $$HOME/go/bin/tbls.$(RESET)\n"; \
+	else \
+		printf "$(YELLOW)⚠️  tbls not found, installing to $$HOME/go/bin...$(RESET)\n"; \
+		go install github.com/k1LoW/tbls@latest; \
+		if [ -f "$$HOME/go/bin/tbls" ]; then \
+			printf "$(GREEN)✅ tbls installed successfully in $$HOME/go/bin/tbls.$(RESET)\n"; \
+		else \
+			printf "$(RED)❌ Failed to install tbls.$(RESET)\n"; \
+			printf "$(YELLOW)💡 Please ensure Go is installed and $$HOME/go/bin is in your PATH.$(RESET)\n"; \
+			exit 1; \
+		fi; \
+	fi
+
+docs-generate: install-tbls ## Generate API documentation
 	@printf "$(BLUE)📚 Generating documentation...$(RESET)\n"
 	@if command -v swag >/dev/null 2>&1; then \
 		swag init -g cmd/server/main.go -o docs/swagger; \
@@ -1741,6 +1760,20 @@ docs-generate: ## Generate API documentation
 		printf "$(YELLOW)⚠️  Swagger not installed$(RESET)\n"; \
 	fi
 	@printf "$(GREEN)✅ Documentation generated$(RESET)\n"
+
+docs-schema: install-tbls ## 💾 Generate database schema documentation using tbls
+	@printf "$(BLUE)💾 Generating database schema documentation...$(RESET)\n"
+	@printf "$(BLUE)   Output will be in ./docs/schema/ $(RESET)\n"
+	@export TBLS_DSN="postgres://$(DB_USER):$(DB_PASSWORD)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)?sslmode=$(DB_SSLMODE)"; \
+	if command -v tbls >/dev/null 2>&1; then \
+		tbls doc -c docs/schema/.tbls.yml; \
+	elif [ -f "$$HOME/go/bin/tbls" ]; then \
+		$$HOME/go/bin/tbls doc -c docs/schema/.tbls.yml; \
+	else \
+		printf "$(RED)❌ tbls command not found. Please ensure it is installed and in your PATH.$(RESET)\n"; \
+		exit 1; \
+	fi
+	@printf "$(GREEN)✅ Database schema documentation generated.$(RESET)\n"
 
 docs-serve: ## Serve documentation locally
 	@printf "$(BLUE)📚 Serving documentation...$(RESET)\n"

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -542,6 +542,31 @@ idx_audit_logs_timestamp    -- Audit queries
 idx_rate_limits_key         -- Rate limit checks
 ```
 
+### Schema Documentation
+
+To help understand the database structure, this project uses `tbls` to generate schema documentation. This documentation provides details about tables, columns, types, and relationships.
+
+**Generating the Documentation:**
+
+1.  **Ensure Environment Variables are Set:** The documentation generation relies on database connection details. Make sure your `.env` file is configured with the correct values for `DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD`, and `DB_NAME` (see `.env.example`). `DB_SSLMODE` will default to `disable` if not set.
+2.  **Run the Makefile Target:**
+    ```bash
+    make docs-schema
+    ```
+    Alternatively, you can run `make docs` which includes schema documentation along with other documentation generation steps.
+
+This command will use `tbls` to connect to the database, inspect its schema, and output Markdown files into the `docs/schema/` directory. The main documentation file will be `docs/schema/README.md` (or `docs/schema/<DB_NAME>.md`).
+
+**ER Diagram (Optional):**
+
+`tbls` can also generate an Entity Relationship (ER) diagram. The configuration for this is in `docs/schema/.tbls.yml` (commented out by default). To enable it:
+    1. Uncomment the `er` section in `docs/schema/.tbls.yml`.
+    2. Ensure you have PlantUML (for `.puml` output) and Graphviz (for formats like `.png`, `.svg`) installed and available in your system's PATH.
+
+**Keeping Documentation Updated:**
+
+The generated documentation in `docs/schema/` should be committed to version control. For recommendations on how to automatically update this documentation as part of your CI/CD pipeline, refer to the CI integration recommendations provided when this feature was added, or check the project's CI configuration files.
+
 ## Monitoring & Observability
 
 ### Metrics

--- a/docs/schema/.tbls.yml
+++ b/docs/schema/.tbls.yml
@@ -1,0 +1,27 @@
+# DSN will be provided via TBLS_DSN environment variable
+# To add table/column comments or descriptions, you can create additional YAML files
+# in this directory (e.g., schema.yml) and reference them here.
+# For example:
+# docPath: "docs/schema"
+# format: {} # Optional: further output formatting options
+
+# Specifies the directory where .md files are generated.
+# This path is relative to the directory where tbls is executed.
+# If tbls is run from the repo root, this will output to docs/schema/
+out: "docs/schema"
+
+# ER Diagram (optional: requires PlantUML and Graphviz installed and in PATH)
+# To enable, uncomment the following lines and ensure dependencies are met.
+# er:
+#   format: "plantuml" # or "png", "svg", "jpg"
+#   output: "er.puml"
+#   # distance: 1
+#   # comments: true
+
+# Optional: Specify which tables to include or exclude
+# tables:
+#   include:
+#     - "public.users" # Example: only include the users table in the public schema
+#   exclude:
+#     - "schema_migrations" # Example: exclude the migrations table
+#     - "*_test" # Example: exclude tables ending with _test


### PR DESCRIPTION
This commit introduces a new capability to generate database schema documentation using the `tbls` tool.

Key changes:
- Added `install-tbls` Makefile target: Ensures `tbls` is installed via `go install` if not already present.
- Added `docs-schema` Makefile target: Invokes `tbls doc` to generate schema documentation based on the configuration in `docs/schema/.tbls.yml`. This target is now part of the main `make docs` flow.
- Created `docs/schema/.tbls.yml`: Configuration file for `tbls`.
  - Uses environment variables for database connection details (DSN is constructed in Makefile and passed as `TBLS_DSN`).
  - Configured to output documentation to the `docs/schema/` directory.
  - Includes an optional (commented out) configuration for ER diagram generation, with notes about PlantUML/Graphviz dependencies.
- Updated `docs/DEVELOPMENT.md`: Added a new "Schema Documentation" section explaining how to use the new Makefile target and manage the documentation.

This feature allows developers to easily generate and maintain documentation for the application's database schema, improving understanding and collaboration.

CI Integration Recommendation:
To keep the schema documentation "living", it's recommended to add a CI job that runs `make docs-schema` and commits any changes to the `docs/schema/` directory. This job should trigger after database migrations or on pushes to the main branch. Key steps for such a CI job include:
1. Checkout code.
2. Setup Go environment.
3. Ensure database access with latest migrations.
4. Run `make docs-schema`.
5. Configure a git user, add changes in `docs/schema/`, commit, and push if changes are detected.